### PR TITLE
Fix for blank fragment pager

### DIFF
--- a/library/src/main/java/xyz/santeri/wvp/WrappingFragmentPagerAdapter.java
+++ b/library/src/main/java/xyz/santeri/wvp/WrappingFragmentPagerAdapter.java
@@ -35,13 +35,14 @@ public abstract class WrappingFragmentPagerAdapter extends FragmentPagerAdapter 
             throw new UnsupportedOperationException("ViewPager is not a WrappingViewPager");
         }
 
-        if (position != mCurrentPosition) {
-            Fragment fragment = (Fragment) object;
-            WrappingViewPager pager = (WrappingViewPager) container;
-            if (fragment != null && fragment.getView() != null) {
+
+        Fragment fragment = (Fragment) object;
+        WrappingViewPager pager = (WrappingViewPager) container;
+        if (fragment != null && fragment.getView() != null) {
+            if (position != mCurrentPosition) {
                 mCurrentPosition = position;
-                pager.onPageChanged(fragment.getView());
             }
+            pager.onPageChanged(fragment.getView());
         }
     }
 }

--- a/library/src/main/java/xyz/santeri/wvp/WrappingFragmentStatePagerAdapter.java
+++ b/library/src/main/java/xyz/santeri/wvp/WrappingFragmentStatePagerAdapter.java
@@ -35,13 +35,13 @@ public abstract class WrappingFragmentStatePagerAdapter extends FragmentStatePag
             throw new UnsupportedOperationException("ViewPager is not a WrappingViewPager");
         }
 
-        if (position != mCurrentPosition) {
-            Fragment fragment = (Fragment) object;
-            WrappingViewPager pager = (WrappingViewPager) container;
-            if (fragment != null && fragment.getView() != null) {
+        Fragment fragment = (Fragment) object;
+        WrappingViewPager pager = (WrappingViewPager) container;
+        if (fragment != null && fragment.getView() != null) {
+            if (position != mCurrentPosition) {
                 mCurrentPosition = position;
-                pager.onPageChanged(fragment.getView());
             }
+            pager.onPageChanged(fragment.getView());
         }
     }
 }


### PR DESCRIPTION
Problem: Blank page because of mCurrentView is null

Regenerate problem steps:

 1. Utilize the navigation component (AAC) to navigate among fragments.
 
 2. Let your fragments contain "Wrapping-viewpager"

 3. When you come back to the fragment which has the pager, the mCurrentView is null thus the page is blank.

Solution: Call "onPageChanged" everytime event position hasn't changed.